### PR TITLE
feat: copier.yml に Staging 設定を追加

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -78,12 +78,14 @@ cloudflare_project_name:
   help: |
     Cloudflare Pages のプロジェクト名を入力してください。
   when: "{{ install_staging }}"
+  validator: "{% if not cloudflare_project_name %}プロジェクト名は必須です{% endif %}"
 
 cloudflare_account_id:
   type: str
   help: |
     Cloudflare のアカウント ID を入力してください。
   when: "{{ install_staging }}"
+  validator: "{% if not cloudflare_account_id %}アカウント ID は必須です{% endif %}"
 
 # =============================================================================
 # Claude モデル・ターン数設定


### PR DESCRIPTION
## 概要

copier.yml に Staging/Preview 環境の有効化フラグ、Cloudflare 関連質問、_exclude 条件を追加。

## 変更点

- `install_staging` フラグ（type: bool, default: false）を追加
- Cloudflare 関連質問（cloudflare_project_name, cloudflare_account_id）を install_staging=true 時のみ表示
- _exclude に Staging 関連パスの条件除外を追加

Closes #36

## 動作確認

- [ ] install_staging=false 時に Staging 関連ファイルが除外されること
- [ ] install_staging=true 時に Cloudflare 関連質問が表示されること
- [ ] install_workflows と独立して動作すること

Generated with [Claude Code](https://claude.ai/code)